### PR TITLE
Fix the registered inputBinding associated to 'modal'

### DIFF
--- a/inst/www/shinyBS.js
+++ b/inst/www/shinyBS.js
@@ -29,7 +29,9 @@ $.extend(shinyBS.inputBindings.modal, {
     return $(el).hasClass("in");
   },
   subscribe: function(el, callback) {
-    $(el).on("hidden.bs.modal shown.bs.modal", callback)
+    $(el).on("hidden.bs.modal shown.bs.modal", function () {
+      callback(true);
+    })
   },
   unsubscribe: function(el) {
     $(el).off("hidden.bs.modal shown.bs.modal")

--- a/inst/www/shinyBS.js
+++ b/inst/www/shinyBS.js
@@ -29,9 +29,7 @@ $.extend(shinyBS.inputBindings.modal, {
     return $(el).hasClass("in");
   },
   subscribe: function(el, callback) {
-    $(el).on("hidden.bs.modal shown.bs.modal", function () {
-      callback(true);
-    })
+    $(el).on("hidden.bs.modal shown.bs.modal", () => callback(true));
   },
   unsubscribe: function(el) {
     $(el).off("hidden.bs.modal shown.bs.modal")


### PR DESCRIPTION
Attempt to fix the bug https://github.com/federicomarini/shinyBS/issues/1

The callback argument of the 'subscribe' function is invoked by receiving a boolean value to comply with the [SubscribeEventPriority](https://github.com/rstudio/shiny/blob/07af5f91c86050b73c477bde78dea0303b6bc656/srcts/src/bindings/input/inputBinding.ts#L5C6-L5C28) type.
