### PR TITLE
Fix the registered inputBinding associated to 'collapse'

### DIFF
--- a/inst/www/shinyBS.js
+++ b/inst/www/shinyBS.js
@@ -98,7 +98,7 @@ $.extend(shinyBS.inputBindings.collapse, {
     }
   },
   subscribe: function(el, callback) {
-    $(el).find(".collapse").on("shown.bs.collapse hidden.bs.collapse", callback);
+    $(el).find(".collapse").on("shown.bs.collapse hidden.bs.collapse", () => callback(true));
   },
   initialize: function(el) {
     var $el = $(el);


### PR DESCRIPTION
Should fix the bug https://github.com/federicomarini/shinyBS/issues/3

Sorry, @federicomarini, I didn't catch the issue sooner. I looked at the other implementations of “SubscribeEventPriority,” and they seem to be correct.